### PR TITLE
Fix sponsors partners link

### DIFF
--- a/src/sections/10.sponsors.js
+++ b/src/sections/10.sponsors.js
@@ -51,17 +51,35 @@ export default () => {
             <Row css="@media screen and (min-width: 768px) {margin-bottom: 3rem;}">
               <Col>
                 <h3>Platinum Sponsor</h3>
-                <Img fluid={data.spdigital.childImageSharp.fluid} />
+                <a
+                  href="https://www.spdigital.io/"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <Img fluid={data.spdigital.childImageSharp.fluid} />
+                </a>
               </Col>
             </Row>
             <Row>
               <Col>
                 <h3>Gold Sponsor</h3>
-                <Img fluid={data.shopify.childImageSharp.fluid} />
+                <a
+                  href="https://www.shopify.com/careers/search?locations%5B%5D=43&keywords=&sort="
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <Img fluid={data.shopify.childImageSharp.fluid} />
+                </a>
               </Col>
               <Col>
                 <h3>Silver Sponsor</h3>
-                <Img fluid={data.microsoft.childImageSharp.fluid} />
+                <a
+                  href="https://www.facebook.com/MicrosoftSG/"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <Img fluid={data.microsoft.childImageSharp.fluid} />
+                </a>
               </Col>
             </Row>
           </div>

--- a/src/sections/12.partners.js
+++ b/src/sections/12.partners.js
@@ -55,7 +55,13 @@ export default () => (
                 </a>
               </Col>
               <Col>
-                <img alt="Junction X Singapore" src={junction} />
+                <a
+                  href="https://singapore.hackjunction.com/"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <img alt="Junction X Singapore" src={junction} />
+                </a>
               </Col>
             </Row>
             <Row>


### PR DESCRIPTION
This fix enables links when hovering over the image of sponsors and partners