### PR TITLE
Fix malformed JSON on landing page

### DIFF
--- a/src/sections/1.landing.js
+++ b/src/sections/1.landing.js
@@ -87,7 +87,6 @@ export default ({ title }) => {
                 <i className="c-g">: </i>
                 <i className="c-b">"</i>2020-09-19T18:00
                 <i className="c-b">"</i>
-                <i className="c-g">,</i>
               </code>
               <code>
                 {`    `}
@@ -118,11 +117,10 @@ export default ({ title }) => {
                 <i className="c-g">: </i>
                 <i className="c-b">"</i>2020-09-20T18:00
                 <i className="c-b">"</i>
-                <i className="c-g">,</i>
               </code>
               <code>
                 {`    `}
-                <i className="c-g">{`}`},</i>
+                <i className="c-g">{`}`}</i>
               </code>
               <code>
                 {`  `}
@@ -133,7 +131,7 @@ export default ({ title }) => {
                 <i className="c-b">"</i>
                 <i className="c-r">location</i>
                 <i className="c-b">"</i>
-                <i className="c-g">:</i>
+                <i className="c-g">: </i>
                 <i className="c-b">"</i>Online
                 <i className="c-b">"</i>
                 <i className="c-g">,</i>
@@ -149,12 +147,12 @@ export default ({ title }) => {
               <code>
                 {`    `}
                 <i>afternoon geek talks.</i>
-                <i className="c-b">"</i>
+                <i className="c-b">",</i>
               </code>
               <code>
                 {`  `}
                 <i className="c-b">"</i>
-                <i className="c-y">Registration</i>
+                <i className="c-y">registration</i>
                 <i className="c-b">"</i>
                 <i className="c-g">: </i>
                 <i className="c-b">
@@ -168,7 +166,6 @@ export default ({ title }) => {
                   </a>
                 </i>
                 <i className="c-b">"</i>
-                <i className="c-g">,</i>
               </code>
               <code>
                 <i className="c-g">{`}`}</i>


### PR DESCRIPTION
## Fix malformed JSON
* Remove invalid trailing commas on lines `6, 10, 11, 16`
* Add missing comma on line `15`

## Style improvements
* Make spacing consistent after `location`
* Make casing consistent on `Registration`

<img width="1402" alt="Screenshot 2020-09-15 at 6 58 16 PM" src="https://user-images.githubusercontent.com/5736715/93203230-a2f70f00-f786-11ea-80f9-0d8054ee68bc.png">
