### PR TITLE
Adopt page-default spacing for CFP section

### DIFF
--- a/src/sections/3.cfp.js
+++ b/src/sections/3.cfp.js
@@ -15,17 +15,17 @@ const CallForPapers = () => (
       <div className="vessel cols">
         <div className="left">
           <h2>
-            Give a <br /> Talk?
+            Calling <br /> for papers!
           </h2>
         </div>
         <div className="right">
-          <CallForPapersText>
+          <p>
             We are calling for volunteers and talk proposals to craft / build / hack an experience that every participant will never forget.
             It could be targeted at the general audience (headline track) or a technical deep-dive you're excited to share about (parallel track).
-          </CallForPapersText>
-          <CallForPapersText>
+          </p>
+          <p>
             Send us your ideas and proposals here: <a href="https://www.papercall.io/geekcampsg2022">https://www.papercall.io/geekcampsg2022</a>
-          </CallForPapersText>
+          </p>
         </div>
       </div>
     </div>

--- a/src/sections/3.cfp.js
+++ b/src/sections/3.cfp.js
@@ -5,10 +5,6 @@ const SectionCallForPapers = styled.section`
   margin-top: 3.5rem;
 `
 
-const CallForPapersText = styled.p`
-  font-size: 1.555555556rem;
-`
-
 const CallForPapers = () => (
   <SectionCallForPapers className="section-cfp" id="about">
     <div className="contain">


### PR DESCRIPTION
<img width="825" alt="image" src="https://user-images.githubusercontent.com/710625/181687964-1471752f-3003-4f08-a39a-cf98280477f7.png">
Adopt font size and spacing from the page defaults in the CFP section