### PR TITLE
Slightly improve the tweet styles

### DIFF
--- a/src/pages/_/Testimonials/Tweet.astro
+++ b/src/pages/_/Testimonials/Tweet.astro
@@ -18,6 +18,7 @@ const formattedHtml = html
     display: inline-block;
     scroll-snap-align: start;
     width: 550px;
+    max-width: 85vw;
   }
   .tweet :global(*) {
     box-sizing: border-box;
@@ -65,11 +66,9 @@ const formattedHtml = html
   }
   .tweet :global(.MediaCard-mediaContainer) {
     position: relative;
+    padding-bottom: 0 !important; /* override the aspect ratio hack */
   }
   .tweet :global(.MediaCard-mediaAsset .NaturalImage-image) {
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
     height: 100%;
   }
@@ -86,5 +85,11 @@ const formattedHtml = html
   .tweet :global(.TweetInfo-timeGeo) {
     font-size: 13px;
     color: #71767b;
+  }
+  .tweet :global(.u-hidden) {
+    display: none;
+  }
+  .tweet :global(.QuoteTweet-link) {
+    text-decoration: none;
   }
 </style>


### PR DESCRIPTION
Slight improvements:

1. Apply `85vw` max-width so that the tweet would fit in smaller phones (width).
2. Images were kinda cropped in a weird way because there's the `padding-bottom` hack vs the better `object-fit: cover;` fix. Seems… kinda work.
3. Once `position: absolute` got removed from the images, a weird cookie-consent interstitial "By playing this video you agree to Twitter's use of cookies" appears below the baby GIF, so that's set to hidden thanks to the useful `u-hidden` class.
4. Remove hover underline from the quoted tweet.