### PR TITLE
Clean up for 2025

### DIFF
--- a/src/data/cfp.ts
+++ b/src/data/cfp.ts
@@ -1,3 +1,3 @@
-export const deadline = new Date('2025-11-31');
+export const deadline = new Date('2025-11-30');
 export const link = 'https://sessionize.com/geekcampsg2025';
 export const name = 'Apply now!';

--- a/src/data/cfp.ts
+++ b/src/data/cfp.ts
@@ -1,3 +1,3 @@
-export const deadline = new Date('2024-10-31');
-export const link = 'https://sessionize.com/geekcampsg2024';
+export const deadline = new Date('2025-11-31');
+export const link = 'https://sessionize.com/geekcampsg2025';
 export const name = 'Apply now!';

--- a/src/data/date.ts
+++ b/src/data/date.ts
@@ -1,6 +1,6 @@
-export const year = 2024;
+export const year = 2025;
 // Used by terminal for the date command
-export const date = new Date('2024-12-07T10:00:00+08:00');
+export const date = new Date('2025-12-13T10:00:00+08:00');
 // Used by the hero
-export const startDate = new Date('2024-12-07T10:00:00+08:00');
-export const endDate = new Date('2024-12-07T18:00:00+08:00');
+export const startDate = new Date('2025-12-13T10:00:00+08:00');
+export const endDate = new Date('2025-12-13T18:00:00+08:00');

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -1,7 +1,7 @@
 export const volunteerLink = 'https://forms.gle/DeszWwSdEY423dj89';
 export const discordLink = '/discord';
 export const discordInviteUrl = 'https://discord.gg/26ydZDKhVp';
-export const ticketLink = 'https://www.eventbrite.sg/e/geekcampsg-2024-tickets-1051654455787';
-export const venueLink = 'https://google.com/maps?q=SMU+connexion';
-export const venueName = '40 Stamford Rd, SMU Connexion, Level 5';
+export const ticketLink = '';
+export const venueLink = '';
+export const venueName = 'TBC!';
 export const venueDirectionsLink = "/directions";

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -1,4 +1,4 @@
-export const volunteerLink = 'https://forms.gle/DeszWwSdEY423dj89';
+export const volunteerLink = '';
 export const discordLink = '/discord';
 export const discordInviteUrl = 'https://discord.gg/26ydZDKhVp';
 export const ticketLink = '';

--- a/src/pages/_/Hero/handleTerminal.ts
+++ b/src/pages/_/Hero/handleTerminal.ts
@@ -123,7 +123,11 @@ export default function handleTerminal({
             val = 'Registration is not open yet';
           }
         } else if (cmd === 'volunteer') {
-          val = `<a href="${volunteerLink}">Volunteer with us</a>`;
+          if (volunteerLink) {
+            val = `<a href="${volunteerLink}">Volunteer with us!</a>`;
+          } else {
+            val = 'Shoot a message in the <a href="${discordLink}">Discord</a> if you are interested!';
+          }
         } else if (cmd === 'location') {
           val = `In-person: <a href="${venueLink}">${venueName}</a><br>Online: <a href="${discordLink}">Discord</a>`;
         } else if (cmd === 'dir') {
@@ -149,7 +153,7 @@ export default function handleTerminal({
             val += `${diff} more day${diff > 1 ? 's' : ''} to go!`;
           }
         } else if (cmd === 'contact') {
-          val = 'geekcampsingapore at gmail dot com';
+          val = 'please send a message in <a href="${discordLink}">Discord</a>!';
         } else if (cmd === 'archives') {
           val = '<a href="/past-events">View past events</a>';
         } else if (cmd === 'game') {

--- a/src/pages/_/Hero/index.astro
+++ b/src/pages/_/Hero/index.astro
@@ -25,13 +25,13 @@ const data = formatter()
   .addEntry("startDate", startDate ? `${format.format(startDate)}` : "TBC", true)
   .addEntry("endDate", endDate ? `${format.format(endDate)}` : "TBC")
   .addEntry("inPersonLocation", `<a href="${venueLink}">${venueName}</a>.`)
-  .addEntry("directions", `<a href="${venueDirectionsLink}">How to get here?</a>`)
+//.addEntry("directions", `<a href="${venueDirectionsLink}">How to get here?</a>`)
 //.addEntry("inPersonLocation", `${venueName}`)
 
   .addEntry("onlineLocation", `<a href="${discordLink}">Discord</a>`)
   .addEntry("registration", `<a href="${ticketLink}">Get tickets!</a>`, true)
   //.addEntry("registration", `TBC`)
-  .addEntry("volunteer", `<a href="${volunteerLink}">Join us!</a>`, true)
+//.addEntry("volunteer", `<a href="${volunteerLink}">Join us!</a>`, true)
   .addEntry(
     "cfp",
     +Date.now() > +cfp.deadline

--- a/src/pages/_/Schedule/index.astro
+++ b/src/pages/_/Schedule/index.astro
@@ -5,7 +5,7 @@ import { formatDateLong } from "@src/utils/date-format"
 ---
 
 {
-  schedule.dates.map((date) => {
+  /* schedule.dates.map((date) => {
     return (
       <section id="schedule" class="rows">
         <>
@@ -26,7 +26,19 @@ import { formatDateLong } from "@src/utils/date-format"
         </>
       </section>
     )
-  })
+  }) */
+ <section id="schedule" class="rows">
+        <>
+          <div>
+            <h2>Schedule - 2025</h2>
+          </div>
+          <div>
+            <p>
+			        Watch this space! Want to speak? Submit a talk proposal via <a href="/cfp">CFP</a>!
+            </p>
+          </div>
+        </>
+      </section>
 }
 
 <style>

--- a/src/pages/_/Schedule/index.astro
+++ b/src/pages/_/Schedule/index.astro
@@ -1,5 +1,6 @@
 ---
 import Schedules from "./_/Schedules.svelte"
+import * as cfp from '@src/data/cfp';
 import { schedule, tracks, gridUrl } from "@src/data/schedules/current"
 import { formatDateLong } from "@src/utils/date-format"
 ---
@@ -34,7 +35,7 @@ import { formatDateLong } from "@src/utils/date-format"
           </div>
           <div>
             <p>
-			        Watch this space! Want to speak? Submit a talk proposal via <a href="/cfp">CFP</a>!
+			        Watch this space! Want to speak? Submit a talk proposal via <a href={cfp.link}>sessionize</a>!
             </p>
           </div>
         </>

--- a/src/pages/_/Sponsors/index.astro
+++ b/src/pages/_/Sponsors/index.astro
@@ -6,7 +6,7 @@ import smuai from './logos/smuai.png';
 import smuiie from './logos/smuiie.png';
 import stack from './logos/STACK.png';
 
-const sponsors: Array<{
+/* const sponsors: Array<{
   title: string;
   size: number;
   sponsors: Array<{
@@ -27,15 +27,7 @@ const sponsors: Array<{
         name: 'SmuAI',
         description:
           'SmuAI (https://www.smuai.me/) is a student-led ThinkTank that facilitates the sharing of ideas in the field of Artificial Intelligence.',
-      },
-
-      {
-        link: 'https://iie.smu.edu.sg/',
-        image: smuiie,
-        name: 'SMU Institute of Innovation and Entrepreneurship (IIE)',
-        description:
-          'At SMU Institute of Innovation and Entrepreneurship (IIE), we understand what it means to be an entrepreneur. We strive to help aspiring innovators build their foundation and seed the entrepreneurial mindset. Powered by knowledge and driven by heart, we nurture changemakers and founders who aspire to make the world a better place.',
-      },
+      }
     ],
   },
 
@@ -51,17 +43,19 @@ const sponsors: Array<{
       },
     ],
   },
-];
+]; */
 ---
 
 {
-  sponsors.length > 0 ? (
-    <section id="sponsors" class="rows">
+/*   sponsors.length > 0 ? (
+ committing out for now*/ 
+      true ? (   
+      <section id="sponsors" class="rows">
       <div>
         <h2>Sponsors</h2>
       </div>
       <div>
-        {sponsors.map((category) => {
+        {/* {sponsors.map((category) => {
           return (
             <div class="row">
               {category.title ? (
@@ -89,7 +83,8 @@ const sponsors: Array<{
               </div>
             </div>
           );
-        })}
+        })} */}
+      Interested in possibly sponsoring GeekcampSG? Reach out to us on <a href="/discord">Discord</a>!
       </div>
     </section>
   ) : null

--- a/src/pages/_/Testimonials/index.astro
+++ b/src/pages/_/Testimonials/index.astro
@@ -1,6 +1,7 @@
 ---
 import Tweets from "./Tweets.astro"
 const tweetUrls = [
+  "https://x.com/edkesuma/status/1865343891324768737",
   "https://twitter.com/subhransu/status/1562416772866707456",
   "https://twitter.com/coderkungfu/status/1586245073838088192",
   "https://twitter.com/Knguyentrieu/status/1185475318858928129",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ import { schedule, speakers } from "@src/data/schedules/current"
   <Sponsors />
   <!-- <LocalTechCommunities /> -->
   {schedule.dates.length > 0 ? <Schedule /> : null}
-  {speakers.length > 0 ? <Speakers /> : null}
+  <!-- {speakers.length > 0 ? <Speakers /> : null} -->
   <Testimonials />
   <CodeOfConduct />
   <Organisers />


### PR DESCRIPTION
Updates the GeekCamp SG website for the 2025 edition
- change dates and venue
- ADD cfp!!!

- update terminal command, volunteer link to discord and empty link handling and contact command to go to discord
- hide speakers and schedule
- replace sponsors with sponsorship inquiry blurb
- add tweet for 2024 testimonial

todo: 
- get volunteer links?
- get registration?
- update venue